### PR TITLE
Added Service_GetStatus call

### DIFF
--- a/src/CustomActions/SystemTools/ServiceImpl.h
+++ b/src/CustomActions/SystemTools/ServiceImpl.h
@@ -100,3 +100,12 @@ CA_API UINT __stdcall Service_GetConfig(MSIHANDLE hInstall);
 \return SERVICE_EXISTS set to "1" if service exists, "0" otherwise
 */
 CA_API UINT __stdcall Service_Exists(MSIHANDLE hInstall);
+
+/*! 
+
+\brief Get status of a service
+\param SERVICE_NAME service name
+\return SERVICE_STATUS set to one of: Stopped, Starting, Stopping, Running, Resuming, Pausing, Paused depending on the current service state. If service does not exist SERVICE_STATUS is set to Absent.
+*/
+CA_API UINT __stdcall Service_GetStatus(MSIHANDLE hInstall);
+

--- a/src/CustomActions/SystemTools/ServiceImplUnitTests.cpp
+++ b/src/CustomActions/SystemTools/ServiceImplUnitTests.cpp
@@ -21,6 +21,7 @@ void ServiceImplUnitTests::Test_EntryPoints()
 	CPPUNIT_ASSERT(NULL != GetProcAddress(h, "Service_Delete"));
 	CPPUNIT_ASSERT(NULL != GetProcAddress(h, "Service_GetConfig"));
 	CPPUNIT_ASSERT(NULL != GetProcAddress(h, "Service_Exists"));
+	CPPUNIT_ASSERT(NULL != GetProcAddress(h, "Service_GetStatus"));
 	::FreeLibrary(h);
 }
 
@@ -217,4 +218,22 @@ void ServiceImplUnitTests::Test_Service_Exists()
 	msiInstall.SetProperty(L"SERVICE_NAME", AppSecInc::Com::GenerateGUIDStringW());
 	CPPUNIT_ASSERT(ERROR_SUCCESS == hInstall.ExecuteCA(L"SystemTools.dll", L"Service_Exists"));
 	CPPUNIT_ASSERT(L"0" == msiInstall.GetProperty(L"SERVICE_EXISTS"));
+}
+
+void ServiceImplUnitTests::Test_Service_GetStatus()
+{
+	AppSecInc::Msi::MsiShim hInstall;
+	MsiInstall msiInstall(hInstall);
+
+	msiInstall.SetProperty(L"SERVICE_NAME", L"W32Time");
+	CPPUNIT_ASSERT(ERROR_SUCCESS == hInstall.ExecuteCA(L"SystemTools.dll", L"Service_GetStatus"));
+	CPPUNIT_ASSERT(L"Running" == msiInstall.GetProperty(L"SERVICE_STATUS"));
+
+	msiInstall.SetProperty(L"SERVICE_NAME", L"WerSvc");
+	CPPUNIT_ASSERT(ERROR_SUCCESS == hInstall.ExecuteCA(L"SystemTools.dll", L"Service_GetStatus"));
+	CPPUNIT_ASSERT(L"Stopped" == msiInstall.GetProperty(L"SERVICE_STATUS"));
+
+	msiInstall.SetProperty(L"SERVICE_NAME", AppSecInc::Com::GenerateGUIDStringW());
+	CPPUNIT_ASSERT(ERROR_SUCCESS == hInstall.ExecuteCA(L"SystemTools.dll", L"Service_GetStatus"));
+	CPPUNIT_ASSERT(L"Absent" == msiInstall.GetProperty(L"SERVICE_STATUS"));
 }

--- a/src/CustomActions/SystemTools/ServiceImplUnitTests.h
+++ b/src/CustomActions/SystemTools/ServiceImplUnitTests.h
@@ -18,6 +18,7 @@ namespace AppSecInc
 				CPPUNIT_TEST( Test_Service_Delete );
 				CPPUNIT_TEST( Test_Service_GetConfig );
 				CPPUNIT_TEST( Test_Service_Exists );
+				CPPUNIT_TEST( Test_Service_GetStatus );
 				CPPUNIT_TEST_SUITE_END();
 			private:
 				std::wstring service_name;
@@ -33,6 +34,7 @@ namespace AppSecInc
                 void Test_Service_Control();
 				void Test_Service_GetConfig();
 				void Test_Service_Exists();
+				void Test_Service_GetStatus();
 			};
 		}
 	}

--- a/src/CustomActions/SystemTools/SystemTools.def
+++ b/src/CustomActions/SystemTools/SystemTools.def
@@ -35,6 +35,7 @@ EXPORTS
 	Service_ChangeDescription
 	Service_GetConfig
 	Service_Exists
+	Service_GetStatus
 	TemplateFiles_Immediate
 	TemplateFiles_Deferred
 	Registry_CopyBranch


### PR DESCRIPTION
Added Service_GetStatus call for immediate custom action returning service status name in the SERVICE_STATUS property - one of: Running, Stopped, Starting, Stopping, Resuming, Pausing, Paused, or Absent when service does not exist.
Target service name is provided in the SERVICE_NAME property.
