### PR TITLE
Adding optional attribute "Escape" to TemplateFileProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     * Added `SERVICE_NAME` as an alternative property for specifying service name in Service_Change... calls  - [@vladaver](https://github.com/vladaver).
     * [#8](https://github.com/dblock/msiext/pull/8) - Added `Service_GetState` immediate custom action - [@vladaver](https://github.com/vladaver).
     * [#21](https://github.com/dblock/msiext/pull/21) - Added `ExecuteOnReinstall` for SystemTools::TemplateFile - [@wojwal](https://github.com/wojwal).
+    * [#23](https://github.com/dblock/msiext/pull/23) - Added optional attribute "Escape" to TemplateFileProperty - [@wojwal](https://github.com/wojwal).
   * **Bugs**:
     * [#9](https://github.com/dblock/msiext/issues/9) - Fixed build failures if WiX Toolset v3.7 or MSBuild Community Tasks are not installed - [@icnocop](https://github.com/icnocop).
   * **Misc**:

--- a/src/Common/String/StringUtils.cpp
+++ b/src/Common/String/StringUtils.cpp
@@ -551,3 +551,17 @@ void AppSecInc::StringUtils::ebcdic2s(unsigned char * s, unsigned long len)
 	    s[i] = EBCDIC_to_ASCII[s[i]];
     }
 }
+
+std::wstring AppSecInc::StringUtils::escape(std::wstring const &s)
+{
+    std::size_t n = s.length();
+    std::wstring escaped;
+    escaped.reserve(n * 2);        // pessimistic preallocation
+
+    for (std::size_t i = 0; i < n; ++i) {
+        if (s[i] == L'\\' || s[i] == L'"')
+            escaped += L'\\';
+        escaped += s[i];
+    }
+    return escaped;
+}

--- a/src/Common/String/StringUtils.h
+++ b/src/Common/String/StringUtils.h
@@ -223,6 +223,8 @@ namespace AppSecInc
 	    bool endsWith(const std::string& ss, const std::string& what);
 	    bool endsWith(const std::wstring& ss, const std::wstring& what);
 
+	    std::wstring escape(std::wstring const &s);
+
 	    //! Convert any streamable data into a UNICODE string.
 	    template<class T>
 	    std::wstring toWString(const T& t)

--- a/src/CustomActions/SystemTools/TemplateFiles.cpp
+++ b/src/CustomActions/SystemTools/TemplateFiles.cpp
@@ -97,9 +97,12 @@ CA_API UINT __stdcall TemplateFiles_Immediate(MSIHANDLE hInstall)
 
 		            std::wstring name = xmlPropertiesDocument.GetNodeValue(L"Data[@Column=\"Name\"]", property_row);
 		            std::wstring value = xmlPropertiesDocument.GetNodeValue(L"Data[@Column=\"Value\"]", property_row);
+		            std::wstring escape = xmlPropertiesDocument.GetNodeValue(L"Data[@Column=\"Escape\"]", property_row);
+
                     MSXML2::IXMLDOMNodePtr property_node = combined_xml_document.AppendChild(L"Property", properties_node);
                     combined_xml_document.SetAttribute(L"name", name, property_node);
                     combined_xml_document.SetAttribute(L"value", value, property_node);
+                    combined_xml_document.SetAttribute(L"escape", escape, property_node);
 		        }
             }
         }
@@ -144,7 +147,8 @@ CA_API UINT __stdcall TemplateFiles_Deferred(MSIHANDLE hInstall)
             {
                 std::wstring name = xmlDocument.GetAttributeValue(L"name", property_row);
                 std::wstring value = xmlDocument.GetAttributeValue(L"value", property_row);
-                properties[name] = value;
+                long escape = AppSecInc::StringUtils::stringToLong(xmlDocument.GetAttributeValue(L"escape", property_row, L"0"));
+                properties[name] = escape == 1 ? AppSecInc::StringUtils::escape(value) : value;
             }
         }
 

--- a/src/WixExtensions/SystemToolsExtension/wixext/Data/tables.xml
+++ b/src/WixExtensions/SystemToolsExtension/wixext/Data/tables.xml
@@ -55,6 +55,7 @@
     <columnDefinition name="TemplateFileId" type="string" length="72" modularize="column" category="identifier" keyTable="TemplateFiles" keyColumn="1" />
     <columnDefinition name="Name" type="string" length="0" modularize="property" category="formatted" />
     <columnDefinition name="Value" type="string" length="0" modularize="property" category="formatted" nullable="yes" />
+    <columnDefinition name="Escape" type="number" length="2" nullable="yes" minValue="0" maxValue="1" />
   </tableDefinition>
   <tableDefinition name="RegistryCopy">
     <columnDefinition name="Id" type="string" length="72" primaryKey="yes" modularize="column" category="identifier" />

--- a/src/WixExtensions/SystemToolsExtension/wixext/SystemToolsCompiler.cs
+++ b/src/WixExtensions/SystemToolsExtension/wixext/SystemToolsCompiler.cs
@@ -883,6 +883,7 @@ namespace AppSecInc.Wix.Extensions
             string id = null;
             string name = null;
             string value = null;
+            int escape = 0;
 
             foreach (XmlAttribute attrib in node.Attributes)
             {
@@ -898,6 +899,9 @@ namespace AppSecInc.Wix.Extensions
                             break;
                         case "Value":
                             value = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "Escape":
+                            escape = this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib) == YesNoType.Yes ? 1 : 0;
                             break;
                         default:
                             this.Core.UnexpectedAttribute(sourceLineNumbers, attrib);
@@ -943,6 +947,7 @@ namespace AppSecInc.Wix.Extensions
                 row[1] = templatefileid;
                 row[2] = name;
                 row[3] = value;
+                row[4] = escape;
             }
         }
 

--- a/src/WixExtensions/SystemToolsExtension/wixext/Xsd/SystemTools.xsd
+++ b/src/WixExtensions/SystemToolsExtension/wixext/Xsd/SystemTools.xsd
@@ -590,6 +590,11 @@ TemplateFileProperty with a value.
               <xs:documentation>Value of the property.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="Escape" type="YesNoType" use="optional">
+            <xs:annotation>
+              <xs:documentation>Escape value.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>


### PR DESCRIPTION
Hi, 

This is what I needed for my project... As mentioned before I needed the path to have double slashes...

Sample usage:
```
<SystemTools:TemplateFileProperty Id="FILENAME_property" Name="Filepath" Value="[INSTALLDIR]somefile.exe" Escape="yes" />
```

Not a big deal - and it's optional... Hope you will merge it ;)