### PR TITLE
Add a twin dialog of ServiceCredDlg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+###  1.6 (Next Release)
+  * **Bugs**:
+    * [#27](https://github.com/dblock/msiext/issues/27) - Fixed that the username control in `ServiceCredDlg` doesn't get refreshed after user has previously typed in the control - [@atwayne](https://github.com/atwayne)
+  * **Breaking Changes**: 
+    * `ServiceCredDlg` now should be used along with `ServiceCredTwinDlg` with same setup.
+
 ###  1.5 (9/18/2015)
 
   * **Features**:

--- a/src/Demos/CommonUiMsi/CommonUiMsi.wxs
+++ b/src/Demos/CommonUiMsi/CommonUiMsi.wxs
@@ -44,6 +44,7 @@
             <DialogRef Id="RuntimeDbCredDlg" />
             <DialogRef Id="DbCreateCredDlg" />
             <DialogRef Id="ServiceCredDlg" />
+            <DialogRef Id="ServiceCredTwinDlg" />
             <DialogRef Id="ServicePortDlg" />
             <DialogRef Id="GenericErrorDlg" />
 
@@ -61,6 +62,9 @@
 
             <Publish Dialog="ServiceCredDlg" Control="Next" Event="NewDialog" Value="ServicePortDlg">NOT Installed</Publish>
             <Publish Dialog="ServiceCredDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
+
+            <Publish Dialog="ServiceCredTwinDlg" Control="Next" Event="NewDialog" Value="ServicePortDlg">NOT Installed</Publish>
+            <Publish Dialog="ServiceCredTwinDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
 
             <Publish Dialog="ServicePortDlg" Control="Next" Event="NewDialog" Value="SelectDbDlg">NOT Installed</Publish>
             <Publish Dialog="ServicePortDlg" Control="Back" Event="NewDialog" Value="ServiceCredDlg">NOT Installed</Publish>

--- a/src/WixExtensions/CommonUiExtension/wixext/Xsd/CommonUi.xsd
+++ b/src/WixExtensions/CommonUiExtension/wixext/Xsd/CommonUi.xsd
@@ -15,6 +15,8 @@ Provides a set of dialogs that are commonly used in AppSecInc product installers
 The dialogs included in this extention are:
 \li \c ServiceCredDlg - Allows the user to specify a Windows account or Local System. Includes 
        a test button that checks that the account is valid and has the Logon as Service permission.
+\li \c ServiceCredTwinDlg - A identical dialog of ServiceCredDlg that should be referenced with 
+       the same setup with the ServiceCredDlg.
 \li \c ServicePortDlg - Allows the specification of a port. Includes a test button that checks
        that the port is valid and available.
 \li \c SelectDbDlg - Allows the selection of a SQL database server.
@@ -33,6 +35,7 @@ in the dialog sequence.
 <UI>	
 	<!-- CommonU UI Dialogs-->
 	<DialogRef Id="ServiceCredDlg" />
+	<DialogRef Id="ServiceCredTwinDlg" />
 	<DialogRef Id="GenericErrorDlg" />
 	
 	<!-- UIExtension Dialogs-->
@@ -49,6 +52,9 @@ in the dialog sequence.
 	
 	<Publish Dialog="ServiceCredDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">NOT Installed</Publish>
 	<Publish Dialog="ServiceCredDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
+
+	<Publish Dialog="ServiceCredTwinDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">NOT Installed</Publish>
+	<Publish Dialog="ServiceCredTwinDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">NOT Installed</Publish>
 
 	<Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="RuntimeDbCredDlg">NOT Installed</Publish>
 

--- a/src/WixExtensions/CommonUiExtension/wixlib/CommonUiExtension.wixproj
+++ b/src/WixExtensions/CommonUiExtension/wixlib/CommonUiExtension.wixproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common.wxs" />
+    <Compile Include="ServiceCredTwinDlg.wxs" />
     <Compile Include="GenericErrorDlg.wxs" />
     <Compile Include="RuntimeDbCredDlg.wxs" />
     <Compile Include="ServiceCredDlg.wxs" />

--- a/src/WixExtensions/CommonUiExtension/wixlib/ServiceCredDlg.wxs
+++ b/src/WixExtensions/CommonUiExtension/wixlib/ServiceCredDlg.wxs
@@ -9,7 +9,8 @@
         <Property Id="SERVICE_PASSWORD" Hidden="yes" />
 
         <UI>
-            <!--
+          <DialogRef Id="ServiceCredTwinDlg"/>
+          <!--
                 Prompts for service credentials.
     
                 \param SERVICE_LOGON_TYPE one of ServiceAccount or ServiceLocalSystem
@@ -81,6 +82,8 @@
                     <Publish Event="DoAction" Value="AsiUI_DirectoryObjectPicker" Order="2">1</Publish>
                     <Publish Property="SERVICE_USERNAME" Value="[DSOP_UPN]" Order="3"><![CDATA[DSOP_UPN <> ""]]></Publish>
                     <Publish Property="SERVICE_USERNAME" Value="[DSOP_NAME]" Order="3"><![CDATA[DSOP_NAME <> "" AND DSOP_UPN = ""]]></Publish>
+                    <!-- launch another identical dialog to refresh the value of Username Control -->
+                    <Publish Event="NewDialog" Value="ServiceCredTwinDlg">1</Publish>
                 </Control>
 
                 <Control Id="PasswordLabel" Type="Text" X="40" Y="170" Width="41" Height="10" TabSkip="no" Text="!(loc.ServiceCredDlg_PasswordLabel)">

--- a/src/WixExtensions/CommonUiExtension/wixlib/ServiceCredTwinDlg.wxs
+++ b/src/WixExtensions/CommonUiExtension/wixlib/ServiceCredTwinDlg.wxs
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+      <UI>
+            <!--
+                This is a copy of ServiceCredDlg with small modifications.
+                Modification has been highlighted as comment.
+                
+                This identical dialog has been introduced to fix the following issue.
+                https://github.com/dblock/msiext/issues/27
+                Which is caused by a limitation of MSI UI not refreshing the value of an Edit control after user has typed anything in the control.
+                As a result of this behavior if property has been set in a custom action if will not be refreshed in UI.
+                
+                The idea of the fix is to launch a identical dialog after the custom action.
+                During the launch UI will be refreshed.
+            -->
+            <!-- Diff: ServiceCredDlg -> ServiceCredTwinDlg -->
+            <Dialog Id="ServiceCredTwinDlg" Width="370" Height="270" Title="!(loc.ServiceCredDlg_Header)">
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)">
+                    <Publish Property="SERVICE_LOGON_TYPE" Value="[SERVICE_LOGON_TYPE]">1</Publish>
+                    <Publish Property="SERVICE_USERNAME" Value="[SERVICE_USERNAME]"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Property="SERVICE_PASSWORD" Value="[SERVICE_PASSWORD]"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Property="SERVICE_USERNAME"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Publish>
+                    <Publish Property="SERVICE_PASSWORD"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Publish>
+                    <Condition Action="disable"><![CDATA[(LOGON_VALID <> "1" OR LOGON_HAS_PRIVILEGE <> "1" OR LOGON_IS_MEMBER <> "1") AND SERVICE_LOGON_TYPE = "ServiceAccount" AND TEST_CONNECTIONS <> "0" AND (VersionNT > 500 OR VersionNT64)]]></Condition>
+                    <Condition Action="enable"><![CDATA[(LOGON_VALID = "1" AND LOGON_HAS_PRIVILEGE = "1" AND LOGON_IS_MEMBER = "1") OR SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Publish Property="SERVICE_DISPLAY_USERNAME" Value="[SERVICE_USERNAME]"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Property="SERVICE_DISPLAY_USERNAME" Value="LocalSystem"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Publish>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="6" Width="220" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.ServiceCredDlg_Title)" />
+                <Control Id="SubTitle" Type="Text" X="25" Y="23" Width="200" Height="20" Transparent="yes" NoPrefix="yes" Text="!(loc.ServiceCredDlg_SubTitle)" />
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.ServiceCredDlg_BannerBitmap)" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+
+                <Control Id="Description" Type="Text" X="20" Y="55" Width="330" Height="40" Text="!(loc.ServiceCredDlg_Description)" />
+
+                <Control Id="SelectorLabel" Type="Text" X="20" Y="103" Width="330" Height="10" Text="!(loc.ServiceCredDlg_SelectorLabel)" />
+                <Control Id="ServiceType" Type="RadioButtonGroup" X="20" Y="118" Width="290" Height="30" Property="SERVICE_LOGON_TYPE">
+                  <!-- 
+                    Diff: RadioButtonGroup definition has been removed to avoid LGHT0003 error
+                    This control is linked to the one in original dialog via the Property attribute
+                  -->
+                </Control>
+
+                <Control Id="UsernameLabel" Type="Text" X="40" Y="155" Width="41" Height="10" TabSkip="no" Text="!(loc.ServiceCredDlg_UsernameLabel)">
+                    <Condition Action="disable"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="enable"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                </Control>
+                <Control Id="Username" Type="Edit" X="81" Y="153" Width="150" Height="15" Property="SERVICE_USERNAME" Text="{64}">
+                    <Condition Action="disable"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="enable"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                    <Publish Property="LOGON_VALID" Value="0">1</Publish>
+                    <!-- look for "\" or "@" -->
+                    <Publish Property="REGEX_MATCH_INPUT_STRING" Value="[SERVICE_USERNAME]"><![CDATA[SERVICE_USERNAME <> ""]]></Publish>
+                    <Publish Property="REGEX_MATCH_EXPRESSION" Value=".*(\\|@).*"><![CDATA[SERVICE_USERNAME <> ""]]></Publish>
+                    <Publish Event="DoAction" Value="AsiUI_Regex_Match"><![CDATA[SERVICE_USERNAME <> ""]]></Publish>
+                    <Publish Property="SERVICE_USERNAME" Value="[ComputerName]\[SERVICE_USERNAME]"><![CDATA[SERVICE_USERNAME <> "" AND REGEX_MATCH_RESULT = "0"]]></Publish>
+                </Control>
+                <Control Id="UsernameBrowse" Type="PushButton" X="236" Y="153" Width="56" Height="15" Text="!(loc.ServiceCredDlg_UsernameBrowse)">
+                    <Condition Action="disable"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="enable"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                    <Condition Action="show"><![CDATA[SERVICE_LOGON_BROWSE]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT SERVICE_LOGON_BROWSE]]></Condition>
+                    <!-- browse for a user -->
+                    <Publish Property="DSOP_SCOPE_TYPES" Value="DSOP_SCOPE_TYPE_TARGET_COMPUTER|DSOP_SCOPE_TYPE_EXTERNAL_UPLEVEL_DOMAIN|DSOP_SCOPE_TYPE_ENTERPRISE_DOMAIN" Order="1">1</Publish>
+                    <Publish Property="DSOP_SCOPE_FLAGS" Value="DSOP_SCOPE_FLAG_STARTING_SCOPE|DSOP_SCOPE_FLAG_DEFAULT_FILTER_USERS" Order="1">1</Publish>
+                    <Publish Property="DSOP_SCOPE_FILTER_FLAGS" Value="DSOP_FILTER_USERS" Order="1">1</Publish>
+                    <Publish Property="DSOP_DOWNLEVEL_SCOPE_FILTER_FLAGS" Value="DSOP_DOWNLEVEL_FILTER_USERS" Order="1">1</Publish>
+                    <Publish Event="DoAction" Value="AsiUI_DirectoryObjectPicker" Order="2">1</Publish>
+                    <Publish Property="SERVICE_USERNAME" Value="[DSOP_UPN]" Order="3"><![CDATA[DSOP_UPN <> ""]]></Publish>
+                    <Publish Property="SERVICE_USERNAME" Value="[DSOP_NAME]" Order="3"><![CDATA[DSOP_NAME <> "" AND DSOP_UPN = ""]]></Publish>
+                    <!-- Diff: Launch the original dialog ServiceCredDlg -->
+                    <Publish Event="NewDialog" Value="ServiceCredDlg">1</Publish>
+                </Control>
+
+                <Control Id="PasswordLabel" Type="Text" X="40" Y="170" Width="41" Height="10" TabSkip="no" Text="!(loc.ServiceCredDlg_PasswordLabel)">
+                    <Condition Action="disable"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="enable"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                </Control>
+                <Control Id="Password" Password="yes" Type="Edit" X="81" Y="168" Width="150" Height="15" Property="SERVICE_PASSWORD">
+                    <Condition Action="disable"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="enable"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                    <Publish Property="LOGON_VALID" Value="0">1</Publish>
+                </Control>
+
+                <!-- \todo Testing credentials on Vista requires elevation, ElevationShield just puts a pretty icon here -->
+                <Control Id="Test" Type="PushButton" X="40" Y="193" Width="100" Height="15" Text="!(loc.ServiceCredDlg_AccountTestLabel)">
+                    <Condition Action="disable"><![CDATA[SERVICE_LOGON_TYPE <> "ServiceAccount" OR LOGON_VALID = "1"]]></Condition>
+                    <Condition Action="enable"><![CDATA[SERVICE_LOGON_TYPE = "ServiceAccount" AND LOGON_VALID <> "1"]]></Condition>
+                    <Condition Action="hide"><![CDATA[VersionNT <= 500]]></Condition>
+
+                    <!-- check whether the credentials are valid -->
+                    <Publish Property="LOGON_USERNAME" Value="[SERVICE_USERNAME]" Order="1">1</Publish>
+                    <Publish Property="LOGON_PASSWORD" Value="[SERVICE_PASSWORD]" Order="1">1</Publish>
+                    <Publish Property="LOGON_TYPE" Value="LOGON32_LOGON_NETWORK" Order="1">1</Publish>
+                    <Publish Event="DoAction" Value="AsiUI_CheckCredentials" Order="2">1</Publish>
+                    <Publish Property="ERROR_MESSAGE" Order="3">1</Publish>
+                    <Publish Property="USERNAME_PASSWORD_VALID" Value="[LOGON_VALID]" Order="4">1</Publish>
+                    <Publish Property="ERROR_TITLE" Value="!(loc.ServiceCredDlg_InvalidLogonErrorTitle)" Order="5">1</Publish>
+                    <Publish Property="ERROR_MESSAGE" Value="[LOGON_ERROR]" Order="6"><![CDATA[LOGON_ERROR <> "" AND USERNAME_PASSWORD_VALID = "0"]]></Publish>
+                    <Publish Property="ERROR_MESSAGE" Value="!(loc.ServiceCredDlg_InvalidLogonError)" Order="7"><![CDATA[LOGON_ERROR = "" AND USERNAME_PASSWORD_VALID = "0"]]></Publish>
+
+                    <!-- check whether this user has logon as a service privilege, only if username/password is valid -->
+                    <Publish Property="LOGON_TYPE" Value="LOGON32_LOGON_SERVICE" Order="8"><![CDATA[USERNAME_PASSWORD_VALID = "1"]]></Publish>
+                    <Publish Property="ERROR_MESSAGE" Order="8"><![CDATA[USERNAME_PASSWORD_VALID = "1"]]></Publish>
+                    <Publish Event="DoAction" Value="AsiUI_CheckCredentialsWithPrivilege" Order="9"><![CDATA[USERNAME_PASSWORD_VALID = "1"]]></Publish>
+                    <Publish Property="LOGON_HAS_PRIVILEGE" Value="[LOGON_VALID]" Order="10"><![CDATA[USERNAME_PASSWORD_VALID = "1"]]></Publish>
+                    <Publish Property="ERROR_MESSAGE" Value="!(loc.ServiceCredDlg_AccountDoesNotHaveLogonAsServiceRights)" Order="11"><![CDATA[USERNAME_PASSWORD_VALID = "1" AND LOGON_HAS_PRIVILEGE = "0"]]></Publish>
+
+                    <!-- check whether this user is an administrator. S-1-5-32-544 is the SID of the Administrators group -->
+                    <Publish Property="IMPERSONATE_LOGON_TYPE" Value="LOGON32_LOGON_NETWORK" Order="21"><![CDATA[SERVICE_REQUIRE_ADMIN AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Property="IMPERSONATE_USERNAME" Value="[SERVICE_USERNAME]" Order="21"><![CDATA[SERVICE_REQUIRE_ADMIN AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Property="IMPERSONATE_PASSWORD" Value="[SERVICE_PASSWORD]" Order="22"><![CDATA[SERVICE_REQUIRE_ADMIN AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Property="SID" Value="S-1-5-32-544" Order="23"><![CDATA[SERVICE_REQUIRE_ADMIN AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Publish>
+                    <Publish Event="DoAction" Value="AsiUI_CheckMembership" Order="24"><![CDATA[SERVICE_REQUIRE_ADMIN AND USERNAME_PASSWORD_VALID = "1" AND LOGON_HAS_PRIVILEGE="1"]]></Publish>
+                    <Publish Property="ERROR_MESSAGE" Value="!(loc.ServiceCredDlg_AccountNotInAdministratorsGroup)" Order="26"><![CDATA[SERVICE_REQUIRE_ADMIN AND USERNAME_PASSWORD_VALID = "1" AND LOGON_HAS_PRIVILEGE = "1" AND LOGON_IS_MEMBER = "0" AND ERROR_MESSAGE = ""]]></Publish>
+
+                    <!-- Need to publish this so that the installer can move on if adminstrative user is not required -->
+                    <Publish Property="LOGON_IS_MEMBER" Value="1">NOT SERVICE_REQUIRE_ADMIN</Publish>
+
+                    <!-- spawn error dialog, ERROR_MESSAGE will be set accordingly -->
+                    <Publish Event="SpawnDialog" Value="GenericErrorDlg" Order="31"><![CDATA[USERNAME_PASSWORD_VALID = "0" OR LOGON_HAS_PRIVILEGE = "0" OR LOGON_IS_MEMBER = "0"]]></Publish>
+                    <!-- clear impersonation properties for any subsequent CA -->
+                    <Publish Property="IMPERSONATE_USERNAME" Order="32">1</Publish>
+                    <Publish Property="IMPERSONATE_PASSWORD" Order="33">1</Publish>
+                </Control>
+                <Control Id="TestResult_Success" Type="Icon" IconSize="16" X="145" Y="194" Width="12" Height="12" Text="AsiUI_SuccessIco">
+                    <Condition Action="hide"><![CDATA[LOGON_VALID = "0" OR LOGON_HAS_PRIVILEGE = "0" OR LOGON_IS_MEMBER = "0" OR SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="show"><![CDATA[LOGON_VALID = "1" AND LOGON_HAS_PRIVILEGE = "1" AND LOGON_IS_MEMBER = "1" AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                </Control>
+                <Control Id="TestResult_Failure" Type="Icon" IconSize="16" X="145" Y="194" Width="12" Height="12" Text="AsiUI_ErrorIco">
+                    <Condition Action="hide"><![CDATA[(LOGON_VALID = "1" AND LOGON_HAS_PRIVILEGE = "1" AND LOGON_IS_MEMBER = "1") OR SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="show"><![CDATA[(LOGON_VALID = "0" OR LOGON_HAS_PRVILEGE = "0" OR LOGON_IS_MEMBER = "0") AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                </Control>
+                <Control Id="TestPrompt" Type="Text" X="160" Y="196" Width="155" Height="10" Text="!(loc.ServiceCredDlg_TestPrompt)">
+                    <Condition Action="hide"><![CDATA[(LOGON_VALID = "1" AND LOGON_HAS_PRIVILEGE = "1" AND LOGON_IS_MEMBER = "1") OR SERVICE_LOGON_TYPE <> "ServiceAccount"]]></Condition>
+                    <Condition Action="show"><![CDATA[(LOGON_VALID = "0" OR LOGON_HAS_PRIVILEGE = "0" OR LOGON_IS_MEMBER = "0") AND SERVICE_LOGON_TYPE = "ServiceAccount"]]></Condition>
+                </Control>
+            </Dialog>
+      </UI>
+
+    </Fragment>
+</Wix>


### PR DESCRIPTION
This is to address #27 

There is actually a thread in the wix-users mail list ten years ago discussing this issue.
[UI Edit Box not updating](http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/UI-Edit-Box-not-updating-td5077648.html)

And there are a lot of similar issues, for example
[A problem with update an Edit control](http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/A-problem-with-update-an-Edit-control-td6933055.html)

To summarize the threads this is caused by a limitation of MSI UI that, after the user typed anything in an Edit control, it will not update the value in the UI to the property it has bound to. As described in the issue, after the user typed anything in the control, the value from custom action `AsiUI_DirectoryObjectPicker` will be ignored on UI.

It looks like the only solution is to create an identical dialog and redirect between the twin dialogs after the custom action.

This PR implements the solution.