### PR TITLE
Update docs link to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Essentials
 ----------
 
 * [Download v1.5](https://github.com/dblock/msiext/releases/download/1.5/msiext-1.5.zip)
-* [v1.5 Documentation](http://dblock.github.com/msiext/docs/1.5/)
+* [v1.5 Documentation](http://dblock.github.io/msiext/docs/1.5/)
 * [Lots of MSI Demos](src/Demos)
 * [Need Help? Google Group](https://groups.google.com/group/msiext)
 * [Old CodePlex Site](http://msiext.codeplex.com)


### PR DESCRIPTION
The current link to the docs in the README is broken because it points to the old GitHub Pages domain at `dblock.github.com`. The new domain is `dblock.github.io`.